### PR TITLE
Downgrad go version to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CyberAgentHack/server-performance-tuning-2023
 
-go 1.19
+go 1.18
 
 require (
 	entgo.io/ent v0.11.4


### PR DESCRIPTION
AppRunnerがgo1.18しか対応していない([参考](https://docs.aws.amazon.com/apprunner/latest/dg/service-source-code-go1-releases.html))のでgoのバージョンを1.18に下げました！