### PR TITLE
fix(config): not to enable tracing if on cloud9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+default: generate
+
 .PHONY: test
 test:
 	go test -race -cover -parallel 4 ./...
@@ -5,6 +7,10 @@ test:
 .PHONY: run-local
 run-local:
 	@ENV_ENVIRONMENT=local go run main.go
+
+.PHONY: run-cloud9
+run-cloud9:
+	@ENV_ENVIRONMENT=cloud9 go run main.go
 
 .PHONY: generate
 generate:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 func NewConfig(env string, dbSecretName string, redisEndpoint string) (*Config, error) {
 	var cfg *Config
 	switch env {
-	case "prd", "cloud9":
+	case "prd":
 		cfg = &Config{
 			DBConfig: &config.DBConfig{
 				SecretsManagerDBConfig: &config.SecretsManagerDBConfig{
@@ -26,6 +26,18 @@ func NewConfig(env string, dbSecretName string, redisEndpoint string) (*Config, 
 			RedisEndpoint: redisEndpoint,
 			TraceConfig: &TraceConfig{
 				EnableTracing: true,
+			},
+		}
+	case "cloud9":
+		cfg = &Config{
+			DBConfig: &config.DBConfig{
+				SecretsManagerDBConfig: &config.SecretsManagerDBConfig{
+					SecretID: dbSecretName,
+				},
+			},
+			RedisEndpoint: redisEndpoint,
+			TraceConfig: &TraceConfig{
+				EnableTracing: false,
 			},
 		}
 	case "local":


### PR DESCRIPTION
リハ中に発覚した、アプリケーションが起動しない問題の修正です。
cloud9上でアプリケーションを実行する際、X-Rayのトレーシングを有効化しないように修正します。
また、参加学生には基本 `$ make run-cloud9` を使用してもらう案内が必要になります。