### PR TITLE
build(di): redis client

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -75,7 +75,7 @@ func (a *App) runWithContext(ctx context.Context) (err error) {
 	}
 
 	// NOTE: redisクライアントのサンプル実装
-	_, err = db.NewRedisClient(cfg.RedisEndpoint)
+	redis, err := db.NewRedisClient(cfg.RedisEndpoint)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func (a *App) runWithContext(ctx context.Context) (err error) {
 		Genre:          database.NewGenre(mysql),
 		ViewingHistory: database.NewViewingHistory(),
 	}
-	uc := usecase.NewUsecase(database)
+	uc := usecase.NewUsecase(database, redis)
 
 	// run http server
 	service := apphttp.NewService(uc, a.logger)

--- a/pkg/usecase/usecase.go
+++ b/pkg/usecase/usecase.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/singleflight"
 
+	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/db"
 	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/repository"
 )
 
@@ -31,13 +32,15 @@ type Usecase interface {
 
 type UsecaseImpl struct {
 	db       *repository.Database
+	redis    db.RedisClient
 	validate *validator.Validate
 	group    *singleflight.Group
 }
 
-func NewUsecase(db *repository.Database) *UsecaseImpl {
+func NewUsecase(db *repository.Database, redis db.RedisClient) *UsecaseImpl {
 	return &UsecaseImpl{
 		db:       db,
+		redis:    redis,
 		validate: validator.New(),
 		group:    &singleflight.Group{},
 	}


### PR DESCRIPTION
cloud9でのコードジャンプが困難なので、redis clientはDIだけ先にしておくのが良さそうでした(通してみての感想)。