### PR TITLE
refactor(http): request and response package

### DIFF
--- a/pkg/app/http/episode.go
+++ b/pkg/app/http/episode.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/go-chi/chi"
 
-	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/app/http/request"
-	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/app/http/response"
 	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/entity"
 	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/usecase"
 )
@@ -21,16 +19,16 @@ func (s *Service) listEpisodes(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	req := &usecase.ListEpisodesRequest{
-		Limit:    request.QueryIntDefault(r, "limit", 20),
-		Offset:   request.QueryInt(r, "offset"),
-		SeasonID: request.Query(r, "seasonId"),
-		SeriesID: request.Query(r, "seriesId"),
+		Limit:    QueryIntDefault(r, "limit", 20),
+		Offset:   QueryInt(r, "offset"),
+		SeasonID: Query(r, "seasonId"),
+		SeriesID: Query(r, "seriesId"),
 	}
 	resp, err := s.usecase.ListEpisodes(ctx, req)
 	if err != nil {
-		response.Error(err, w, r)
+		s.Error(err, w, r)
 		return
 	}
 
-	response.OK(&entity.ListEpisodesResponse{Episodes: resp.Episodes, Series: resp.Series, Seasons: resp.Seasons}, w, r)
+	s.OK(&entity.ListEpisodesResponse{Episodes: resp.Episodes, Series: resp.Series, Seasons: resp.Seasons}, w, r)
 }

--- a/pkg/app/http/http.go
+++ b/pkg/app/http/http.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/app/http/response"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/go-chi/cors"
@@ -29,7 +28,6 @@ func NewServer(params *ServerParams) *http.Server {
 	)
 	setDefaultHandlers(router)
 	params.Service.Register(router)
-	response.SetLogger(params.Logger)
 	return &http.Server{
 		Addr:    fmt.Sprintf(":%d", params.Port),
 		Handler: router,

--- a/pkg/app/http/mock_test.go
+++ b/pkg/app/http/mock_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"go.uber.org/zap"
 
-	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/app/http/response"
 	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/usecase/mock"
 )
 
@@ -27,7 +26,6 @@ func newService(m *mocks) *Service {
 		now:     time.Now,
 		logger:  zap.NewNop(),
 	}
-	response.SetLogger(s.logger)
 	return s
 }
 

--- a/pkg/app/http/request.go
+++ b/pkg/app/http/request.go
@@ -1,4 +1,4 @@
-package request
+package http
 
 import (
 	"net/http"

--- a/pkg/app/http/request/request.go
+++ b/pkg/app/http/request/request.go
@@ -4,13 +4,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-
-	"github.com/go-chi/chi"
 )
-
-func URLParam(r *http.Request, key string) string {
-	return chi.URLParam(r, key)
-}
 
 func Query(r *http.Request, key string) string {
 	return r.URL.Query().Get(key)
@@ -44,41 +38,4 @@ func QueryInt(r *http.Request, key string) int {
 
 func QueryIntDefault(r *http.Request, key string, def int) int {
 	return int(QueryInt64Default(r, key, int64(def)))
-}
-
-func QueryInt32(r *http.Request, key string) int32 {
-	v := r.URL.Query().Get(key)
-	i, _ := strconv.ParseInt(v, 10, 32)
-	return int32(i)
-}
-
-func QueryDefault(r *http.Request, key, def string) string {
-	v := r.URL.Query().Get(key)
-	if v == "" {
-		return def
-	}
-	return v
-}
-
-func QueryBool(r *http.Request, key string) bool {
-	v, _ := strconv.ParseBool(r.URL.Query().Get(key))
-	return v
-}
-
-func QueryDefaultInt64(r *http.Request, key string, def int64) int64 {
-	v := r.URL.Query().Get(key)
-	i, err := strconv.ParseInt(v, 10, 64)
-	if err != nil || i == 0 {
-		return def
-	}
-	return i
-}
-
-func QueryDefaultInt(r *http.Request, key string, def int) int {
-	v := r.URL.Query().Get(key)
-	i, err := strconv.ParseInt(v, 10, 32)
-	if err != nil || i == 0 {
-		return def
-	}
-	return int(i)
 }

--- a/pkg/app/http/response.go
+++ b/pkg/app/http/response.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	keyCacheControl = "cache-control"
-	keyContentType  = "content-type"
-	keyVary         = "vary"
+	keyCacheControl = "Cache-Control"
+	keyContentType  = "Content-Type"
+	keyVary         = "Vary"
 )
 
 const (

--- a/pkg/app/http/response/response.go
+++ b/pkg/app/http/response/response.go
@@ -2,99 +2,59 @@ package response
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"time"
-
-	"go.uber.org/zap"
 
 	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/errcode"
+)
+
+const (
+	keyCacheControl = "cache-control"
+	keyContentType  = "content-type"
+	keyVary         = "vary"
 )
 
 const (
 	applicationJSON = "application/json"
 )
 
-var logger *zap.Logger
-
-func SetLogger(l *zap.Logger) {
-	logger = l
-}
-
-type Option func(*options)
-
-type options struct {
-	cachable bool
-	smaxage  time.Duration
-}
-
-// setHeaders sets cache control and surrogate keys.
-func setHeaders(h http.Header, opts ...Option) {
-	dopt := &options{}
-	for i := range opts {
-		opts[i](dopt)
+func Send(status int, msg interface{}, w http.ResponseWriter, r *http.Request) {
+	w.Header().Set(keyVary, "accept,accept-encoding,origin")
+	if w.Header().Get(keyCacheControl) == "" {
+		w.Header().Set(keyCacheControl, "private,no-store")
 	}
-	// cache control
-	value := "private,no-store"
-	if dopt.cachable {
-		const format = "public,max-age=0,s-maxage=%.0f"
-		value = fmt.Sprintf(format, dopt.smaxage.Seconds())
-	}
-	h.Set("vary", "accept,accept-encoding,origin")
-	h.Set("cache-control", value)
-}
 
-func Send(status int, msg interface{}, w http.ResponseWriter, r *http.Request, opts ...Option) {
-	// write common headers
-	setHeaders(w.Header(), opts...)
-
-	// nil handling
 	if msg == nil {
 		w.WriteHeader(status)
 		return
 	}
 
-	w.Header().Set("content-type", applicationJSON)
+	w.Header().Set(keyContentType, applicationJSON)
 	w.WriteHeader(status)
 	data, err := json.Marshal(msg)
 	if err != nil {
 		Error(err, w, r)
 		return
 	}
-	if _, err = w.Write(data); err != nil {
-		logger.Error("Failed to send", zap.Any("body", msg), zap.Error(err))
-	}
+	w.Write(data)
 }
 
 func Error(err error, w http.ResponseWriter, r *http.Request) {
-	const internal = 500
 	status := httpStatus(err)
-	if status >= internal {
-		logger.Error("Error occurred", zap.Error(err))
-	}
 	sendError(err, status, w, r)
-}
-
-func sendError(err error, status int, w http.ResponseWriter, r *http.Request) {
-	Send(status, err.Error(), w, r)
 }
 
 func BadRequest(err error, w http.ResponseWriter, r *http.Request) {
 	sendError(err, http.StatusBadRequest, w, r)
 }
 
-func NotFound(w http.ResponseWriter, _ *http.Request) {
-	w.WriteHeader(http.StatusNotFound)
-}
-
-func NoContent(w http.ResponseWriter) {
-	w.WriteHeader(http.StatusNoContent)
+func sendError(err error, status int, w http.ResponseWriter, r *http.Request) {
+	Send(status, err.Error(), w, r)
 }
 
 func httpStatus(err error) int {
 	return errcode.HTTPStatus(err)
 }
 
-func OK(msg interface{}, w http.ResponseWriter, r *http.Request, opts ...Option) {
-	Send(http.StatusOK, msg, w, r, opts...)
+func OK(msg interface{}, w http.ResponseWriter, r *http.Request) {
+	Send(http.StatusOK, msg, w, r)
 }

--- a/pkg/app/http/season.go
+++ b/pkg/app/http/season.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/go-chi/chi"
 
-	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/app/http/request"
-	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/app/http/response"
 	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/entity"
 	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/usecase"
 )
@@ -21,15 +19,15 @@ func (s *Service) listSeasons(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	req := &usecase.ListSeasonsRequest{
-		Limit:    request.QueryIntDefault(r, "limit", 20),
-		Offset:   request.QueryInt(r, "offset"),
-		SeriesID: request.Query(r, "seriesId"),
+		Limit:    QueryIntDefault(r, "limit", 20),
+		Offset:   QueryInt(r, "offset"),
+		SeriesID: Query(r, "seriesId"),
 	}
 	resp, err := s.usecase.ListSeasons(ctx, req)
 	if err != nil {
-		response.Error(err, w, r)
+		s.Error(err, w, r)
 		return
 	}
 
-	response.OK(&entity.ListSeasonsResponse{Seasons: resp.Seasons}, w, r)
+	s.OK(&entity.ListSeasonsResponse{Seasons: resp.Seasons}, w, r)
 }

--- a/pkg/app/http/series.go
+++ b/pkg/app/http/series.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/go-chi/chi"
 
-	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/app/http/request"
-	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/app/http/response"
 	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/entity"
 	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/usecase"
 )
@@ -21,14 +19,14 @@ func (s *Service) listSeries(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	req := &usecase.ListSeriesRequest{
-		Limit:  request.QueryIntDefault(r, "limit", 20),
-		Offset: request.QueryInt(r, "offset"),
+		Limit:  QueryIntDefault(r, "limit", 20),
+		Offset: QueryInt(r, "offset"),
 	}
 	resp, err := s.usecase.ListSeries(ctx, req)
 	if err != nil {
-		response.Error(err, w, r)
+		s.Error(err, w, r)
 		return
 	}
 
-	response.OK(&entity.ListSeriesMultiResponse{SeriesMulti: resp.Series, Genres: resp.Genres}, w, r)
+	s.OK(&entity.ListSeriesMultiResponse{SeriesMulti: resp.Series, Genres: resp.Genres}, w, r)
 }

--- a/pkg/app/http/viewing_history.go
+++ b/pkg/app/http/viewing_history.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/go-chi/chi"
 
-	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/app/http/request"
-	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/app/http/response"
 	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/entity"
 	"github.com/CyberAgentHack/server-performance-tuning-2023/pkg/usecase"
 )
@@ -24,17 +22,17 @@ func (s *Service) createViewingHistory(w http.ResponseWriter, r *http.Request) {
 
 	body := &entity.ViewingHistory{}
 	if err := json.NewDecoder(r.Body).Decode(body); err != nil {
-		response.BadRequest(err, w, r)
+		s.BadRequest(err, w, r)
 		return
 	}
 
 	req := &usecase.CreateViewingHistoryRequest{ViewingHistory: body}
 	resp, err := s.usecase.CreateViewingHistory(ctx, req)
 	if err != nil {
-		response.Error(err, w, r)
+		s.Error(err, w, r)
 		return
 	}
-	response.OK(resp.ViewingHistory, w, r)
+	s.OK(resp.ViewingHistory, w, r)
 }
 
 func (s *Service) listViewingHistories(w http.ResponseWriter, r *http.Request) {
@@ -42,20 +40,20 @@ func (s *Service) listViewingHistories(w http.ResponseWriter, r *http.Request) {
 	ctx, span := startTrace(ctx, r, "http.Service#createViewinghistory")
 	defer span.End()
 
-	episodeIDs := request.QueryStrings(r, "episodeIds")
+	episodeIDs := QueryStrings(r, "episodeIds")
 	if len(episodeIDs) == 0 {
-		response.OK(nil, w, r)
+		s.OK(nil, w, r)
 		return
 	}
 	req := &usecase.BatchGetViewingHistoriesRequest{
 		UserID:     r.Header.Get("userId"),
-		EpisodeIDs: request.QueryStrings(r, "episodeIds"),
+		EpisodeIDs: QueryStrings(r, "episodeIds"),
 	}
 	resp, err := s.usecase.BatchGetViewingHistories(ctx, req)
 	if err != nil {
-		response.Error(err, w, r)
+		s.Error(err, w, r)
 		return
 	}
 
-	response.OK(resp.ViewingHistories, w, r)
+	s.OK(resp.ViewingHistories, w, r)
 }


### PR DESCRIPTION
業務コードすぎる箇所を、平易な書き方に修正します。
特に、CDN導入時に付与すべきヘッダーがコードから読み取りづらくなってしまうので、ヘッダーキーと値をハンドラーに明記する方式にしたいと思います(このWSに参加する学生が学びある状態にするため)。

あとは、使っていない関数を削除しています。